### PR TITLE
Improvements to better run against local machine

### DIFF
--- a/src/Common/Invoke-ScriptBlockHandler/Invoke-ScriptBlockHandler.ps1
+++ b/src/Common/Invoke-ScriptBlockHandler/Invoke-ScriptBlockHandler.ps1
@@ -18,7 +18,7 @@ Function Invoke-ScriptBlockHandler {
         Write-VerboseWriter($ScriptBlockDescription)
     }
     try {
-        if ($ComputerName -ne $env:COMPUTERNAME) {
+        if (($ComputerName).Split(".")[0] -ne $env:COMPUTERNAME) {
             $params = @{
                 ComputerName = $ComputerName
                 ScriptBlock  = $ScriptBlock

--- a/src/ComputerInformation/Get-AllNicInformation/Get-AllNicInformation.ps1
+++ b/src/ComputerInformation/Get-AllNicInformation/Get-AllNicInformation.ps1
@@ -64,8 +64,14 @@ Function Get-AllNicInformation {
         )
         try {
             $currentErrors = $Error.Count
-            $cimSession = New-CimSession -ComputerName $ComputerName -ErrorAction Stop
-            $networkIpConfiguration = Get-NetIPConfiguration -CimSession $CimSession -ErrorAction Stop | Where-Object { $_.NetAdapter.MediaConnectionState -eq "Connected" }
+            $params = @{
+                ErrorAction = "Stop"
+            }
+            if (($ComputerName).Split(".")[0] -ne $env:COMPUTERNAME) {
+                $cimSession = New-CimSession -ComputerName $ComputerName -ErrorAction Stop
+                $params.Add("CimSession", $cimSession)
+            }
+            $networkIpConfiguration = Get-NetIPConfiguration @params | Where-Object { $_.NetAdapter.MediaConnectionState -eq "Connected" }
 
             if ($null -ne $CatchActionFunction) {
                 $index = 0


### PR DESCRIPTION
Improvement for `Get-AllNicInformation` and `Invoke-ScriptBlockHandler`. If the script is executed against the local machine and `Fqdn` is passed, the logic to detect if the execution is against the local machine doesn't work well. 
We now split the value which was passed (if possible) and checking the first part of it against `$env:Computername`.