### PR TITLE
Check to see if the local server is an edge server and report back

### DIFF
--- a/src/ExchangeInformation/Confirm-ExchangeShell/Confirm-ExchangeShell.ps1
+++ b/src/ExchangeInformation/Confirm-ExchangeShell/Confirm-ExchangeShell.ps1
@@ -26,6 +26,7 @@ Function Confirm-ExchangeShell {
     }
 
     $passed = $false
+    $edgeTransportKey = 'HKLM:\SOFTWARE\Microsoft\ExchangeServer\v15\EdgeTransportRole'
     $setupKey = 'HKLM:\SOFTWARE\Microsoft\ExchangeServer\v15\Setup'
     Write-VerboseWriter("Calling: Confirm-ExchangeShell")
     Write-VerboseWriter("Passed: [bool]LoadExchangeShell: {0}" -f $LoadExchangeShell)
@@ -63,7 +64,7 @@ Function Confirm-ExchangeShell {
             Write-VerboseWriter("We are on Exchange 2013 or newer")
 
             try {
-                if (Test-Path 'HKLM:\SOFTWARE\Microsoft\ExchangeServer\v15\EdgeTransportRole') {
+                if (Test-Path $edgeTransportKey) {
                     Write-VerboseWriter("We are on Exchange Edge Transport Server")
                     [xml]$PSSnapIns = Get-Content -Path "$env:ExchangeInstallPath\Bin\exshell.psc1" -ErrorAction Stop
 
@@ -101,7 +102,8 @@ Function Confirm-ExchangeShell {
         Minor       = ((Get-ItemProperty -Path $setupKey -Name "MsiProductMinor" -ErrorAction SilentlyContinue).MsiProductMinor)
         Build       = ((Get-ItemProperty -Path $setupKey -Name "MsiBuildMajor" -ErrorAction SilentlyContinue).MsiBuildMajor)
         Revision    = ((Get-ItemProperty -Path $setupKey -Name "MsiBuildMinor" -ErrorAction SilentlyContinue).MsiBuildMinor)
-        ToolsOnly   = $passed -and (Test-Path $setupKey) -and ($null -eq (Get-ItemProperty -Path $setupKey -Name "Services" -ErrorAction SilentlyContinue))
+        EdgeServer  = $passed -and (Test-Path $setupKey) -and (Test-Path $edgeTransportKey)
+        ToolsOnly   = $passed -and (Test-Path $setupKey) -and (!(Test-Path $edgeTransportKey)) -and ($null -eq (Get-ItemProperty -Path $setupKey -Name "Services" -ErrorAction SilentlyContinue))
         RemoteShell = $passed -and (!(Test-Path $setupKey))
     }
 

--- a/src/ExchangeInformation/Confirm-ExchangeShell/README.md
+++ b/src/ExchangeInformation/Confirm-ExchangeShell/README.md
@@ -17,6 +17,7 @@ Major | Provides the Major build of the load computer from the registry
 Minor | Provides the Minor build of the load computer from the registry
 Build | Provides the Build build of the load computer from the registry
 Revision | Provides the Revision build of the load computer from the registry
+EdgeServer | Determines if this is an Exchange Edge Transport Server or not
 ToolsOnly | Determines if this is a tools only computer or not
 RemoteShell | Determines if that we are connect to Exchange Management Shell through a remote shell connection.
 


### PR DESCRIPTION
On an edge server, we don't have the Services item in the SetupKey path. Therefore we think the edge server is a tools box and can cause some logical issues.

Doing a proper check to see if this is an edge server or not.