### PR TITLE
Retry counter to handle enumeration interruptions 

### DIFF
--- a/src/ComputerInformation/Get-AllNicInformation/Get-AllNicInformation.ps1
+++ b/src/ComputerInformation/Get-AllNicInformation/Get-AllNicInformation.ps1
@@ -29,6 +29,7 @@ Function Get-AllNicInformation {
         $nicAdapterBasicPath = "SYSTEM\CurrentControlSet\Control\Class\{4D36E972-E325-11CE-BFC1-08002bE10318}"
         Write-VerboseWriter("Probing started to detect NIC adapter registry path")
         [int]$i = 0
+        [int]$retryCounter = 0
 
         do {
             $nicAdapterPnPCapabilitiesProbingKey = "{0}\{1}" -f $nicAdapterBasicPath, ($i.ToString().PadLeft(4, "0"))
@@ -40,9 +41,13 @@ Function Get-AllNicInformation {
                 break
             } else {
                 Write-VerboseWriter("No matching ComponentId found")
+                if ($null -eq $netCfgInstanceId) {
+                    $retryCounter++
+                    Write-VerboseWriter("Enumeration possibly interrupted. Attempt: {0}/3" -f $retryCounter)
+                }
                 $i++
             }
-        } while ($null -ne $netCfgInstanceId)
+        } while ($retryCounter -le 2)
 
         $obj = New-Object PSCustomObject
         $sleepyNicDisabled = $false


### PR DESCRIPTION
Implemented a retry counter to handle situation in which the sequential number was interrupted like this:

```
HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Class\{4d36e972-e325-11ce-bfc1-08002be10318}
> 0000 (Interface1, MAPI)
> 0001
> 0002
> 0004 (Interface2, Replication)
> 0005
> 0006
```

We try to find another key maximum 3 times. Should be increased to a higher value if more customers reporting false-positives for sleepy nic detection.